### PR TITLE
pairs: display time in seconds instead of ms in tweet

### DIFF
--- a/pairs/www/pairs.js
+++ b/pairs/www/pairs.js
@@ -22,8 +22,8 @@ $(function(){
                 maxCardMargin: 25,
                 onPairDisclosed: function(e) {
                     if (e.finished) {
-                        var time = sw.stopwatch('getTime')
-                        location.href = 'https://twitter.com/intent/tweet?text=' + encodeURIComponent("I just matched ten Gophers in " + time + "ms! Can you beat that? https://pairs.gopherize.me/ #gopherizeme #golang via @ashleymcnamara and @matryer" )
+                        var time = sw.stopwatch('getTime') / 1000
+                        location.href = 'https://twitter.com/intent/tweet?text=' + encodeURIComponent("I just matched ten Gophers in " + time + "s! Can you beat that? https://pairs.gopherize.me/ #gopherizeme #golang via @ashleymcnamara and @matryer" )
                     }
                 }
             })


### PR DESCRIPTION
I don't think the milliseconds resolution is really needed when we tweet
about our success.