### PR TITLE
Make entire panel heading clickable

### DIFF
--- a/gae/static/app.css
+++ b/gae/static/app.css
@@ -58,3 +58,7 @@ footer {
 	max-height: 390px;
 	overflow-y: scroll;
 }
+
+.panel-title a {
+	display: block;
+}


### PR DESCRIPTION
This patch enables users to click anywhere within he panel's header to expand/collapse the panel, without visually changing the UI.